### PR TITLE
Add steps for Terraform Validate and Git Tagging

### DIFF
--- a/steps/terraform_validate.yml
+++ b/steps/terraform_validate.yml
@@ -1,0 +1,16 @@
+parameters:
+  - name: environmentVariables
+    type: object
+    default: []
+  - name: workingDirectory
+    type: string
+
+steps:
+  - script: |
+      terraform init -backend=false
+      terraform validate
+    env:
+      ${{ each var in parameters.environmentVariables }}:
+        ${{ var.key }}: ${{ var.value }}
+    displayName: Terraform Validate
+    workingDirectory: ${{ parameters.workingDirectory }}


### PR DESCRIPTION
- Step for Terraform Validate, currently doesn't initialise backend
- Step that runs Git tagging - note that in order for this to work, the pipeline will need to include an explicit checkout step with `persistCredentials: true`, will look to include this in a wrapper template later