### PR TITLE
Add parameter for agent pool name

### DIFF
--- a/stages/wrapper_cd.yml
+++ b/stages/wrapper_cd.yml
@@ -29,7 +29,10 @@ parameters:
   - name: globalVariables
     type: object
     default: []
-  - name: poolName
+  - name: pool
+    type: object
+    default:
+      name: pins-odt-agent-pool
     type: string
     default: pins-odt-agent-pool
   - name: project
@@ -107,7 +110,7 @@ stages:
                     - ${{ if stage.variables }}:
                       - ${{ each var in stage.variables }}:
                         - ${{ var }}
-          poolName: ${{ parameters.poolName }}
+          pool: ${{ parameters.pool }}
           name: ${{ stage.name }} ${{ environment.name }}
           variables:
             - template: ../variables/environments/${{ lower(environment.name) }}.yml

--- a/stages/wrapper_cd.yml
+++ b/stages/wrapper_cd.yml
@@ -29,6 +29,9 @@ parameters:
   - name: globalVariables
     type: object
     default: []
+  - name: poolName
+    type: string
+    default: pins-odt-agent-pool
   - name: project
     type: string
   - name: variables
@@ -104,6 +107,7 @@ stages:
                     - ${{ if stage.variables }}:
                       - ${{ each var in stage.variables }}:
                         - ${{ var }}
+          poolName: ${{ parameters.poolName }}
           name: ${{ stage.name }} ${{ environment.name }}
           variables:
             - template: ../variables/environments/${{ lower(environment.name) }}.yml

--- a/stages/wrapper_cd.yml
+++ b/stages/wrapper_cd.yml
@@ -33,8 +33,6 @@ parameters:
     type: object
     default:
       name: pins-odt-agent-pool
-    type: string
-    default: pins-odt-agent-pool
   - name: project
     type: string
   - name: variables

--- a/stages/wrapper_ci.yml
+++ b/stages/wrapper_ci.yml
@@ -18,8 +18,6 @@ parameters:
     type: object
     default:
       name: pins-odt-agent-pool
-    type: string
-    default: pins-odt-agent-pool
   - name: projectName
     type: string
     default: ''

--- a/stages/wrapper_ci.yml
+++ b/stages/wrapper_ci.yml
@@ -14,7 +14,10 @@ parameters:
   - name: globalVariables
     type: object
     default: []
-  - name: poolName
+  - name: pool
+    type: object
+    default:
+      name: pins-odt-agent-pool
     type: string
     default: pins-odt-agent-pool
   - name: projectName
@@ -62,7 +65,7 @@ stages:
             - template: ../steps/git_tagging.yml
               parameters:
                 tagPrefix: $(Build.Repository.Name)
-    poolName: ${{ parameters.poolName }}
+    pool: ${{ parameters.pool }}
     name: ${{ parameters.validateName }}
     variables:
       - ${{ each var in parameters.variables }}:

--- a/stages/wrapper_ci.yml
+++ b/stages/wrapper_ci.yml
@@ -14,6 +14,9 @@ parameters:
   - name: globalVariables
     type: object
     default: []
+  - name: poolName
+    type: string
+    default: pins-odt-agent-pool
   - name: projectName
     type: string
     default: ''
@@ -59,6 +62,7 @@ stages:
             - template: ../steps/git_tagging.yml
               parameters:
                 tagPrefix: $(Build.Repository.Name)
+    poolName: ${{ parameters.poolName }}
     name: ${{ parameters.validateName }}
     variables:
       - ${{ each var in parameters.variables }}:

--- a/stages/wrapper_stage.yml
+++ b/stages/wrapper_stage.yml
@@ -9,7 +9,10 @@ parameters:
     type: string
   - name: jobs
     type: jobList
-  - name: poolName
+  - name: pool
+    type: object
+    default:
+      name: pins-odt-agent-pool
     type: string
     default: pins-odt-agent-pool
   - name: variables
@@ -33,4 +36,5 @@ stages:
       - ${{ each job in parameters.jobs }}:
         - ${{ job }}
     pool:
-      name: ${{ parameters.poolName }}
+      ${{ each attribute in parrameters.pool }}:
+        ${{ attribute.key }}: ${{ attribute.value}}

--- a/stages/wrapper_stage.yml
+++ b/stages/wrapper_stage.yml
@@ -13,8 +13,6 @@ parameters:
     type: object
     default:
       name: pins-odt-agent-pool
-    type: string
-    default: pins-odt-agent-pool
   - name: variables
     type: object
     default: []

--- a/stages/wrapper_stage.yml
+++ b/stages/wrapper_stage.yml
@@ -9,6 +9,9 @@ parameters:
     type: string
   - name: jobs
     type: jobList
+  - name: poolName
+    type: string
+    default: pins-odt-agent-pool
   - name: variables
     type: object
     default: []
@@ -30,4 +33,4 @@ stages:
       - ${{ each job in parameters.jobs }}:
         - ${{ job }}
     pool:
-      name: pins-odt-agent-pool
+      name: ${{ parameters.poolName }}


### PR DESCRIPTION
- Adds a parameter for pool name to allow specifying managed agents in the case of `infrastructure-tooling` deployments.