### PR TITLE
Fix terragrunt apply-all working directory

### DIFF
--- a/steps/terragrunt_apply_all.yml
+++ b/steps/terragrunt_apply_all.yml
@@ -16,7 +16,7 @@ steps:
     inputs:
       sourceFolder: $(Pipeline.Workspace)/${{ parameters.artifactName }}
       contents: '**'
-      targetFolder: ${{ parameters.workingDirectory }}
+      targetFolder: $(System.DefaultWorkingDirectory)
     displayName: Copy artifact to working directory
   - script: |
       terragrunt run-all apply --terragrunt-include-external-dependencies


### PR DESCRIPTION
Copy files working directory was wrong as it was pointing at the parameter, which can change.