### PR TITLE
fix(templates): fix deployments to app services where image same as previous by enabling cd

### DIFF
--- a/jobs/wrapper_deployment.yml
+++ b/jobs/wrapper_deployment.yml
@@ -39,7 +39,7 @@ jobs:
             - ${{ if ne(parameters.artifact, '') }}:
               - download: current
                 artifact: ${{ parameters.artifact }}
-                displayName: Download ${{ parameters.artifact }}
+                displayName: Download artifact
             - ${{ else }}:
               - download: none
             - script: |

--- a/steps/azure_web_app_deploy.yml
+++ b/steps/azure_web_app_deploy.yml
@@ -18,26 +18,42 @@ steps:
       echo "##vso[task.setvariable variable=tag]$TAG"
     displayName: Add Docker Image Build Tags
   - script: |
-      IMAGE=${{ parameters.azurecrName }}.azurecr.io/${{ parameters.repository }}:$(tag)
+      IMAGE=${{ parameters.azurecrName }}.azurecr.io/${{ parameters.repository }}
 
       # Check image exists in registry
       az account set -s $(CONTAINER_REGISTRY_SUBSCRIPTION_ID)
       az acr login --name ${{ parameters.azurecrName }}
-      docker manifest inspect $IMAGE > /dev/null
+      docker manifest inspect $IMAGE:$(tag) > /dev/null
       
-      if [ $? -ne 0 ]; then
-        echo "##vso[task.logissue type=error]Image not found in registry."
+      if [[ $? -ne 0 ]]; then
+        echo "##vso[task.logissue type=error]Image/tag not found in registry."
         exit 1
       fi
 
+      docker pull $IMAGE:$(tag)
+      docker tag $IMAGE:$(tag) $IMAGE:$(ENVIRONMENT)
+      docker push $IMAGE:$(ENVIRONMENT)
+
       az account set -s $(SUBSCRIPTION_ID)
 
-      az webapp config container set --name ${{ parameters.appName }} \
-      --resource-group ${{ parameters.appResourceGroup }} \
-      --docker-custom-image-name $IMAGE \
-      --docker-registry-server-url https://${{ parameters.azurecrName }}.azurecr.io \
-      --docker-registry-server-user $AZURE_SERVICE_PRINCIPAL_ID \
-      --docker-registry-server-password $AZURE_SERVICE_PRINCIPAL_SECRET
+      # Check CD enabled for App service and enable if falase
+      CD_ENABLED=$(az webapp deployment container show-cd-url --name ${{ parameters.appName }} --resource-group ${{ parameters.appResourceGroup }} | jq .DOCKER_ENABLE_CI)
+
+      if [[ $CD_ENABLED == "false" ]]; then
+        az webapp deployment container config --enable-cd true --name ${{ parameters.appName }} --resource-group ${{ parameters.appResourceGroup }}
+      fi
+
+      CURRENT_IMAGE_NAME=$(az webapp config container show --name ${{ parameters.appName }} --resource-group ${{ parameters.appResourceGroup }} | jq -r '.[] | select(.name == "DOCKER_CUSTOM_IMAGE_NAME").value')
+      CURRENT_TAG=${CURRENT_IMAGE_NAME#*:}
+
+      if [[ $CURRENT_TAG -ne "$(ENVIRONMENT)"]]; then
+        az webapp config container set --name ${{ parameters.appName }} \
+        --resource-group ${{ parameters.appResourceGroup }} \
+        --docker-custom-image-name $IMAGE:$(ENVIRONMENT) \
+        --docker-registry-server-url https://${{ parameters.azurecrName }}.azurecr.io \
+        --docker-registry-server-user $AZURE_SERVICE_PRINCIPAL_ID \
+        --docker-registry-server-password $AZURE_SERVICE_PRINCIPAL_SECRET
+      fi
     displayName: Deploy Container to Azure Web App
     env:
       AZURE_SERVICE_PRINCIPAL_ID: $(AZURE_SERVICE_PRINCIPAL_ID)

--- a/steps/node_script.yml
+++ b/steps/node_script.yml
@@ -20,6 +20,11 @@ steps:
       source ~/.bashrc
       nvm use ${{ parameters.nodeVersion }}
       ${{ parameters.script }}
+
+      if [[ $? -ne 0 ]]; then
+        echo 
+        exit 1
+      fi
     env:
       ${{ each envVar in parameters.environmentVariables }}:
         ${{ envVar.key }}: ${{ envVar.value }}

--- a/steps/terragrunt_apply_all.yml
+++ b/steps/terragrunt_apply_all.yml
@@ -20,7 +20,7 @@ steps:
     displayName: Copy artifact to working directory
   - script: |
       terragrunt run-all apply --terragrunt-include-external-dependencies
-    displayName: Terragrunt Apply
+    displayName: Terragrunt Apply All
     env:
       ARM_CLIENT_ID: $(AZURE_SERVICE_PRINCIPAL_ID)
       ARM_CLIENT_SECRET: $(AZURE_SERVICE_PRINCIPAL_SECRET)


### PR DESCRIPTION
Fixes app service deployments where the image was same as previous. Done by using the environment as
the tag for deployment, this tag just gets moved when deployments occur. A webhook and the app
service CD feature handle the rest.