### PR TITLE
feat(templates): allow multi-job ci pipeline, update stage/job names, check files step template

### DIFF
--- a/jobs/wrapper_deployment.yml
+++ b/jobs/wrapper_deployment.yml
@@ -23,7 +23,7 @@ parameters:
     default: []
 
 jobs:
-  - deployment: ${{ replace(replace(parameters.name, '-', '_'), ' ', '_') }}
+  - deployment: ${{ replace(replace(replace(replace(parameters.name, '-', '_'), ' ', '_'), '&', 'And'), ',', '') }}
     condition: ${{ parameters.condition }}
     ${{ if parameters.container }}:
       container: ${{ parameters.container }}

--- a/jobs/wrapper_job.yml
+++ b/jobs/wrapper_job.yml
@@ -17,13 +17,13 @@ parameters:
     default: []
 
 jobs:
-  - job: ${{ replace(replace(parameters.name, '-', '_'), ' ', '_') }}
+  - job: ${{ replace(replace(replace(replace(parameters.name, '-', '_'), ' ', '_'), '&', 'And'), ',', '') }}
     condition: ${{ parameters.condition }}
     ${{ if parameters.container }}:
       container: ${{ parameters.container }}
     dependsOn:
       - ${{ each dependsOn in parameters.dependsOn }}:
-        - ${{ dependsOn }}
+        - ${{ replace(replace(replace(replace(dependsOn.name, '-', '_'), ' ', '_'), '&', 'And'), ',', '') }}
     displayName: ${{ parameters.name }}
     steps:
       - ${{ each step in parameters.steps }}:

--- a/stages/wrapper_ci.yml
+++ b/stages/wrapper_ci.yml
@@ -1,7 +1,4 @@
 parameters:
-  - name: azureAuth
-    type: boolean
-    default: true
   - name: container
     type: string
     default: ''
@@ -51,12 +48,19 @@ stages:
                 condition: ${{ job.condition }}
                 container: ${{ job.container }}
                 name: ${{ job.name }}
-                steps: ${{ job.steps }}
+                steps:
+                  - checkout: self
+                    clean: true
+                    persistCredentials: true
+                  - template: ../steps/azure_auth.yml
+                  - ${{ each step in job.steps }}:
+                    - ${{ step }}
                 dependsOn:
                   - ${{ each dependsOn in job.dependsOn }}:
                     - name: ${{ dependsOn }}
-                ${{ if job.variables }}:
-                  variables: ${{ job.variables }}
+                variables:
+                  - ${{ each var in job.variables }}:
+                    - ${{ var }}
         - ${{ if eq(length(parameters.validationJobs), 0) }}:
           - template: ../jobs/wrapper_job.yml
             parameters:
@@ -66,16 +70,10 @@ stages:
                 - checkout: self
                   clean: true
                   persistCredentials: true
+                - template: ../steps/azure_auth.yml
                 - template: ../steps/check_branch_name.yml
-                - ${{ if parameters.azureAuth }}:
-                  - template: ../steps/azure_auth.yml
-                    parameters:
-                      subscriptionId: $(SUBSCRIPTION_ID)
                 - ${{ each validationStep in parameters.validationSteps }}:
                   - ${{ validationStep }}
-                - template: ../steps/git_tagging.yml
-                  parameters:
-                    tagPrefix: $(Build.Repository.Name)
       pool: ${{ parameters.pool }}
       name: ${{ parameters.validateName }}
       variables:

--- a/stages/wrapper_ci.yml
+++ b/stages/wrapper_ci.yml
@@ -17,8 +17,19 @@ parameters:
       name: pins-odt-agent-pool
   - name: validateName
     type: string
+    default: Validate
   - name: validationSteps
     type: stepList
+    default: []
+  - name: validationJobs # A list of custom objects to use in a multi-job validation context.
+    # Structure of each object in the list must match the following:
+    # - name: Name of the job - Mandatory
+    #   condition: Condition under which to run the job - Optional
+    #   container: The name of the container in which to run the job
+    #   dependsOn: List of job names this one is dependent on in the same stage, must be an object/list. - Optional
+    #   steps: stepList of steps to run - Mandatory
+    #   variables: List of job level variables to pass into the agent - Optional
+    type: object
     default: []
   - name: workingDirectory
     type: string
@@ -33,24 +44,38 @@ stages:
   - template: ./wrapper_stage.yml
     parameters:
       jobs:
-        - template: ../jobs/wrapper_job.yml
-          parameters:
-            container: ${{ parameters.container }}
-            name: ${{ parameters.validateName }}
-            steps:
-              - checkout: self
-                clean: true
-                persistCredentials: true
-              - template: ../steps/check_branch_name.yml
-              - ${{ if parameters.azureAuth }}:
-                - template: ../steps/azure_auth.yml
+        - ${{ if ge(length(parameters.validationJobs), 1) }}:
+          - ${{ each job in parameters.validationJobs }}:
+            - template: ../jobs/wrapper_job.yml
+              parameters:
+                condition: ${{ job.condition }}
+                container: ${{ job.container }}
+                name: ${{ job.name }}
+                steps: ${{ job.steps }}
+                dependsOn:
+                  - ${{ each dependsOn in job.dependsOn }}:
+                    - name: ${{ dependsOn }}
+                ${{ if job.variables }}:
+                  variables: ${{ job.variables }}
+        - ${{ if eq(length(parameters.validationJobs), 0) }}:
+          - template: ../jobs/wrapper_job.yml
+            parameters:
+              container: ${{ parameters.container }}
+              name: ${{ parameters.validateName }}
+              steps:
+                - checkout: self
+                  clean: true
+                  persistCredentials: true
+                - template: ../steps/check_branch_name.yml
+                - ${{ if parameters.azureAuth }}:
+                  - template: ../steps/azure_auth.yml
+                    parameters:
+                      subscriptionId: $(SUBSCRIPTION_ID)
+                - ${{ each validationStep in parameters.validationSteps }}:
+                  - ${{ validationStep }}
+                - template: ../steps/git_tagging.yml
                   parameters:
-                    subscriptionId: $(SUBSCRIPTION_ID)
-              - ${{ each validationStep in parameters.validationSteps }}:
-                - ${{ validationStep }}
-              - template: ../steps/git_tagging.yml
-                parameters:
-                  tagPrefix: $(Build.Repository.Name)
+                    tagPrefix: $(Build.Repository.Name)
       pool: ${{ parameters.pool }}
       name: ${{ parameters.validateName }}
       variables:

--- a/stages/wrapper_stage.yml
+++ b/stages/wrapper_stage.yml
@@ -21,7 +21,7 @@ parameters:
     default: $(System.DefaultWorkingDirectory)
   
 stages:
-  - stage: ${{ replace(replace(parameters.name, '-', '_'), ' ', '_') }}
+  - stage: ${{ replace(replace(replace(replace(parameters.name, '-', '_'), ' ', '_'), '&', 'And'), ',', '') }}
     variables:
       - ${{ each var in parameters.variables }}:
         - ${{ var }}

--- a/steps/azure_auth.yml
+++ b/steps/azure_auth.yml
@@ -1,6 +1,7 @@
 parameters:
   - name: subscriptionId
     type: string
+    default: $(SUBSCRIPTION_ID)
 
 steps:
   - script: |

--- a/steps/check_changed_files.yml
+++ b/steps/check_changed_files.yml
@@ -11,8 +11,9 @@
 #           pathFilters:
 #             - name: source_code
 #               path: src
+#           stepName: check_files
 #  - job: B
-#    condition: and(succeeded(), eq(dependencies.A.outputs['checkfiles.source_code'], 'true'))
+#    condition: and(succeeded(), eq(dependencies.A.outputs['check_files.source_code'], 'true'))
 #    dependsOn: A
 #    steps:
 #  - script: echo hello from B
@@ -59,4 +60,4 @@ steps:
     displayName: Check changed files
     env:
       PATH_FILTERS_JSON: ${{ convertToJson(parameters.pathFilters) }}
-    name: check_files
+    name: ${{ parameters.stepName }}

--- a/steps/check_changed_files.yml
+++ b/steps/check_changed_files.yml
@@ -1,0 +1,62 @@
+# Usage:
+# This template checks changed files against the main development branch and sets an output variable for a certain path filter to indicate changes
+# at this location. This variable can then be used in subsequent jobs, for example, to set the condition on which the job should run.
+#
+# Example:
+# jobs:
+#   - job: A
+#     steps:
+#       - template: steps/check_changed_files.yml@templates
+#         parameters:
+#           pathFilters:
+#             - name: source_code
+#               path: src
+#  - job: B
+#    condition: and(succeeded(), eq(dependencies.A.outputs['checkfiles.source_code'], 'true'))
+#    dependsOn: A
+#    steps:
+#  - script: echo hello from B
+
+parameters:
+  - name: condition
+    type: string
+    default: succeeded()
+  - name: developmentBranch
+    type: string
+    default: main
+  - name: pathFilters
+    type: object
+    # Structure of each object:
+    # - name: <variable_name>
+    #   path: <path_filter>
+  - name: stepName
+    type: string
+    default: check_files
+
+steps:
+  - script: |
+      declare -A PATH_FILTERS
+
+      for row in $(echo "$PATH_FILTERS_JSON" | jq -c '.[]'); do
+        PATH_FILTERS[$(echo "$row" | jq -r '.name')]=$(echo "$row" | jq -r '.path')
+      done
+
+      git fetch origin ${{ parameters.developmentBranch }}:${{ parameters.developmentBranch }}
+      CHANGED_FILES=$(git diff ${{ parameters.developmentBranch }}... --name-only)
+
+      echo "Checking for file changes..."
+      for FILE in $CHANGED_FILES; do
+        for KEY in "${!PATH_FILTERS[@]}"; do
+          if [[ $FILE == *${PATH_FILTERS[$KEY]}* ]]; then
+            echo "MATCH: ${FILE} changed"
+            echo "##vso[task.setvariable variable=$KEY;isOutput=true]true"
+          else
+            echo "IGNORE: ${FILE} changed"
+          fi
+        done
+      done
+    condition: ${{ parameters.condition }}
+    displayName: Check changed files
+    env:
+      PATH_FILTERS_JSON: ${{ convertToJson(parameters.pathFilters) }}
+    name: check_files

--- a/steps/node_script.yml
+++ b/steps/node_script.yml
@@ -1,4 +1,7 @@
 parameters:
+  - name: condition
+    type: string
+    default: succeeded()
   - name: environmentVariables
     type: object
     default: []
@@ -25,8 +28,9 @@ steps:
         echo 
         exit 1
       fi
+    condition: ${{ parameters.condition }}
+    displayName: 'Script: ${{ parameters.script }}'
     env:
       ${{ each envVar in parameters.environmentVariables }}:
         ${{ envVar.key }}: ${{ envVar.value }}
-    displayName: Run ${{ parameters.script }}
     workingDirectory: ${{ parameters.workingDirectory }}


### PR DESCRIPTION
Added the ability to specify multi-job CI pipelines, made some updates to allow more characters in
stage/job names, and added a new step template to check changed files.

Implemented for https://pins-ds.atlassian.net/browse/BOCM-490