### PR TITLE
Use dedicated agent pool for Cypress tests

### DIFF
--- a/jobs/cypress_e2e_tests.yml
+++ b/jobs/cypress_e2e_tests.yml
@@ -18,7 +18,7 @@ parameters:
   - name: pool
     type: object
     default:
-      name: pins-odt-agent-pool
+      name: pins-odt-agent-pool-tests
   - name: postTestRunSteps
     type: stepList
     default: []


### PR DESCRIPTION
- Update the default pool name for Cypress end-to-end tests to the newly created tests VMSS agent pool.