### PR TITLE
Output staging URL for App Service slot deployments

### DIFF
--- a/steps/azure_web_app_deploy.yml
+++ b/steps/azure_web_app_deploy.yml
@@ -107,6 +107,11 @@ steps:
             docker push $IMAGE:$(ENVIRONMENT)
           fi
           exit 1
+        else
+          if [[ ! -z "$DEPLOYMENT_SLOT" ]]; then
+            STAGING_URL=$(az webapp config hostname list --webapp-name ${{ parameters.appName }} --resource-group ${{ parameters.appResourceGroup }} --slot ${{ parameters.appStagingSlotName }} | jq '.[].name')
+            echo "##[command]App Service deployment staged to: $STAGING_URL"
+          fi
         fi
       fi
     displayName: Deploy Container to Azure Web App


### PR DESCRIPTION
- Outputs the staging URL e.g. `pins-app-...-staging.azurewebsites.net` to console for easier manual checks before approving the slot swap stage.
- Can't use `${args[@]}` in the `az webapp config hostname list` command due to inconsistancy in the Azure CLI (expects `--webapp-name`, rather than `--name`). 