### PR TITLE
Fix YAML formatting for azure-get-secrets step

### DIFF
--- a/steps/azure_get_secrets.yml
+++ b/steps/azure_get_secrets.yml
@@ -18,9 +18,9 @@ steps:
         if [[ $? -ne 0 ]]; then
           echo "##vso[task.logissue type=error]Could not retrieve secret: ${{ secret.name }}."
           exit 1
-        else
+        fi
         
         SECRET_VALUE=$(echo "$SECRET_JSON" | jq -c -r '.value')
         echo "##vso[task.setvariable variable=${{ secret.variable }};issecret=true]$SECRET_VALUE"
         echo "Secret now available as variable: ${{ secret.variable }}"
-      displayName: Retrieve ${{ secret.name }} secret from Key Vault 
+      displayName: Retrieve ${{ secret.name }} secret from Key Vault

--- a/steps/azure_get_secrets.yml
+++ b/steps/azure_get_secrets.yml
@@ -10,17 +10,17 @@ parameters:
     default: []
 
 steps:
-- ${{ each secret in parameters.secrets }}:
-  - script: |
-      echo "Retrieving secret ${{ secret.name }}..."
-      SECRET_JSON=$(az keyvault secret show -n ${{ secret.name }} --vault-name ${{ parameters.keyVaultName }}; exit $?)
+  - ${{ each secret in parameters.secrets }}:
+    - script: |
+        echo "Retrieving secret ${{ secret.name }}..."
+        SECRET_JSON=$(az keyvault secret show -n ${{ secret.name }} --vault-name ${{ parameters.keyVaultName }}; exit $?)
 
-      if [[ $? -ne 0 ]]; then
-        echo "##vso[task.logissue type=error]Could not retrieve secret: ${{ secret.name }}."
-        exit 1
-      else
-      
-      SECRET_VALUE=$(echo "$SECRET_JSON" | jq -c -r '.value')
-      echo "##vso[task.setvariable variable=${{ secret.variable }};issecret=true]$SECRET_VALUE"
-      echo "Secret now available as variable: ${{ secret.variable }}"
-    displayName: Retrieve ${{ secret.name }} secret from Key Vault 
+        if [[ $? -ne 0 ]]; then
+          echo "##vso[task.logissue type=error]Could not retrieve secret: ${{ secret.name }}."
+          exit 1
+        else
+        
+        SECRET_VALUE=$(echo "$SECRET_JSON" | jq -c -r '.value')
+        echo "##vso[task.setvariable variable=${{ secret.variable }};issecret=true]$SECRET_VALUE"
+        echo "Secret now available as variable: ${{ secret.variable }}"
+      displayName: Retrieve ${{ secret.name }} secret from Key Vault 


### PR DESCRIPTION
Running this step currently returns the following error:
`Retrieving secret back-office-sql-connection-string...`
`/agent/_work/_temp/3dcfd77d-d0c7-4fd5-b230-0eaea565cfde.sh: line 12: syntax error: unexpected end of file`

Expected fix is to indent the loop and script job within the step.