### PR TITLE
fix(templates): fix typo and remove isOutput flag

### DIFF
--- a/steps/terraform_apply.yml
+++ b/steps/terraform_apply.yml
@@ -14,7 +14,7 @@ steps:
         echo "Terraform Plan found..."
       else
         echo "##[warning]No Terraform Plan found, skipping Apply..."
-        echo "##vso[task.setvariable variable=skipApply;isOutput=true]true"
+        echo "##vso[task.setvariable variable=skipApply]true"
       fi
     displayName: Check for Terraform Plan
     workingDirectory: $(Pipeline.Workspace)

--- a/steps/terragrunt_plan.yml
+++ b/steps/terragrunt_plan.yml
@@ -17,7 +17,7 @@ parameters:
 
 steps:
   - script: |
-      terragrunt plan -out=tfplan--terragrunt-ignore-external-dependencies
+      terragrunt plan -out=tfplan --terragrunt-ignore-external-dependencies
     displayName: Terragrunt Plan
     env:
       ARM_CLIENT_ID: $(AZURE_SERVICE_PRINCIPAL_ID)


### PR DESCRIPTION
Fixes a typo in terragrunt plan step for the plan file name, and remove the isOutput flag fromt he
skipApply variable in the terraform apply step.