### PR TITLE
chore: update node_script to use node 18 by default

### DIFF
--- a/steps/node_script.yml
+++ b/steps/node_script.yml
@@ -7,7 +7,7 @@ parameters:
     default: []
   - name: nodeVersion
     type: string
-    default: 16
+    default: 18
     values:
       - 16
       - 15


### PR DESCRIPTION
Update `node_script` step to use Node 18 by default