### PR TITLE
Feat/additional scripts

### DIFF
--- a/steps/azure_container_registry_purge.yml
+++ b/steps/azure_container_registry_purge.yml
@@ -1,0 +1,127 @@
+parameters:
+  - name: azurecrName
+    type: string
+    default: pinscrsharedtoolinguks
+  - name: repositories
+    type: string
+  - name: slotName
+    type: string
+    default: staging
+
+steps:
+  - script: |
+      # Variables
+      REPOS=$(echo '${{ parameters.repositories }}' | jq -r '.[]')
+      echo "Deleting for: ${REPOS[@]}"
+
+      ACR_SUBSCRIPTION="edb1ff78-90da-4901-a497-7e79f966f8e2"
+      APP_SERVICE_SUBSCRIPTIONS=("962e477c-0f3b-4372-97fc-a198a58e259e" "76cf28c6-6fda-42f1-bcd9-6d7dbed704ef" "dbfbfbbf-eb6f-457b-9c0c-fe3a071975bc" "d1d6c393-2fe3-40af-ac27-f5b6bad36735")
+
+      # Fetch all in-use images
+      echo "Fetching in-use images from App Services..."
+      in_use_images=()
+
+      for subscription_id in "${APP_SERVICE_SUBSCRIPTIONS[@]}"; do
+        az account set --subscription "$subscription_id"
+        if [ $? -ne 0 ]; then
+            echo "Failed to set subscription: $subscription_id"
+            exit 1
+        fi
+
+        app_services=$(az webapp list --query "[].{name: name, resourceGroup: resourceGroup}" -o tsv)
+        if [ $? -ne 0 ]; then
+            echo "Failed to list web apps for subscription: $subscription_id"
+            exit 1
+        fi
+        echo "$app_services"
+
+        while IFS=$'\t' read -r name resourceGroup; do
+            echo "$name:$resourceGroup"
+            # Get image for the main app service
+            container_image_name=$(az webapp config container show --name "$name" --resource-group "$resourceGroup")
+            if [ $? -ne 0 ]; then
+                echo "Failed to get container image for app service: $name in resource group: $resourceGroup"
+                exit 1
+            fi
+
+            container_image=$(echo $container_image_name | jq -r '.[] | select(.name == "DOCKER_CUSTOM_IMAGE_NAME").value' | awk -F'|' '{print $2}')
+            if [ -n "$container_image" ]; then
+                in_use_images+=("$container_image")
+                echo "Container Tag Name: $container_image"
+            fi
+
+            # get the slot image
+            slot_image_name=$(az webapp config container show --name "$name" --resource-group "$resourceGroup" --slot "${{ parameters.slotName }}")            
+            if [ $? -ne 0 ]; then
+                echo "Failed to get slot image for app service: $name in resource group: $resourceGroup"
+                exit 1
+            fi
+
+            slot_image=$(echo $slot_image_name | jq -r '.[] | select(.name == "DOCKER_CUSTOM_IMAGE_NAME").value' | awk -F'|' '{print $2}')
+            if [ -n "$slot_image" ]; then
+                in_use_images+=("$slot_image")
+                echo "Slot Tag Name: $slot_image"
+            fi
+        done <<< "$app_services"
+      done
+
+      # Filter out in-use images
+      echo "switching to acr subscription"
+      az account set --subscription "$ACR_SUBSCRIPTION"
+      if [ $? -ne 0 ]; then
+          echo "Error: Failed to set ACR subscription $ACR_SUBSCRIPTION"
+          exit 1
+      fi
+      az acr login --name ${{ parameters.azurecrName }}
+
+
+      for repository in ${REPOS[@]}; do
+        all_tags=$(az acr repository show-tags --name ${{ parameters.azurecrName }} --repository "$repository" --output tsv)
+        # Convert all_tags to an array
+        IFS=$'\n' read -r -d '' -a all_tags_array <<< "$all_tags"
+
+        images_to_purge=()
+        for tag in "${all_tags_array[@]}"; do
+          in_use=false
+          for image in "${in_use_images[@]}"; do
+            if [[ "$image" == "${{ parameters.azurecrName }}.azurecr.io/$repository:$tag" ]]; then
+              in_use=true
+              break
+            fi
+          done
+          if [ "$in_use" = false ]; then
+            images_to_purge+=("$repository:$tag")
+          fi
+        done
+
+        echo "$repository include: ${images_to_purge[@]}"
+
+        for tag in "${images_to_purge[@]}"; do
+            az acr repository delete --name "${{ parameters.azurecrName }}" --image "$tag" --yes
+            if [ $? -ne 0 ]; then
+              echo "Error: Failed to delete ACR $tag"
+              exit 1
+            fi
+        done
+      done
+
+      # Convert images to purge to a regex pattern
+      # include_images=$(IFS='|'; echo "${images_to_purge[*]}")
+      # purge images in include list
+      # filters="^(${include_images})$"
+      # PURGE_CMD="acr purge --ago 14d --dry-run --untagged --filter '$filters'"
+      # az acr run --cmd "$PURGE_CMD" --registry ${{ parameters.azurecrName }} /dev/null
+      # if [ $? -ne 0 ]; then
+      #   echo "Error: Failed to execute purge command"
+      #   exit 1
+      # fi
+      # todo: resolve purge permissions to use purge
+      # ERROR: The resource with name 'pinscrsharedtoolinguks' and type 'Microsoft.ContainerRegistry/registries' could not be found in subscription 'pins-odt-tooling-shared-sub (edb1ff78-90da-4901-a497-7e79f966f8e2)'.
+
+
+      echo "Cleanup completed."
+    name: purgeImagesForRepo
+    displayName: Purge Images For Repo
+    env:
+      AZURE_SERVICE_PRINCIPAL_ID: $(AZURE_SERVICE_PRINCIPAL_ID)
+      AZURE_SERVICE_PRINCIPAL_SECRET: $(AZURE_SERVICE_PRINCIPAL_SECRET)

--- a/steps/azure_web_app_deploy.yml
+++ b/steps/azure_web_app_deploy.yml
@@ -83,7 +83,7 @@ steps:
       if [[ $CURRENT_TAG != "$(ENVIRONMENT)" ]]; then
         echo "##[command]Swapping App Service container to tag: $(ENVIRONMENT)..."
         az webapp config container set \
-        --docker-custom-image-name $IMAGE:$(ENVIRONMENT) \
+        --container-image-name $IMAGE:$(ENVIRONMENT) \
         "${args[@]}"
 
         if [[ $? -ne 0 ]]; then

--- a/steps/azure_web_app_deploy_slot.yml
+++ b/steps/azure_web_app_deploy_slot.yml
@@ -45,7 +45,7 @@ steps:
       docker push $IMAGE:$GIT_COMMIT
 
       echo "##[command]Swapping App Service container to tag: $IMAGE:$GIT_COMMIT..."
-      az webapp config container set --docker-custom-image-name $IMAGE:$GIT_COMMIT "${args[@]}"
+      az webapp config container set --container-image-name $IMAGE:$GIT_COMMIT "${args[@]}"
 
       echo "##[command]Restarting App Service slot"
       az webapp restart "${args[@]}"

--- a/steps/azure_web_app_deploy_slot.yml
+++ b/steps/azure_web_app_deploy_slot.yml
@@ -1,0 +1,60 @@
+parameters:
+  - name: appName
+    type: string
+  - name: appResourceGroup
+    type: string
+  - name: azurecrName
+    type: string
+  - name: repository
+    type: string
+
+steps:
+  - script: |
+      APPNAME=${{ parameters.appName }}
+      IMAGE=${{ parameters.azurecrName }}.azurecr.io/${{ parameters.repository }}
+      FORMATTED_GIT_REF=$(echo $(Build.SourceBranch) | sed "s/refs\/heads\///;s/refs\/tags\///")
+      TAG="${FORMATTED_GIT_REF//\//.}"
+      GIT_COMMIT=$(resources.pipeline.build.sourceCommit)
+
+      echo "IMAGE:$IMAGE"
+      echo "TAG:$TAG"
+      echo "GIT_COMMIT:$GIT_COMMIT"
+
+      echo "logging into az"
+      az account set -s $(CONTAINER_REGISTRY_SUBSCRIPTION_ID)
+      az acr login --name $(azurecrName) || { echo "##vso[task.logissue type=error]Login to container registry failed."; exit 1; }
+
+      echo "##[command]Checking image $IMAGE:$TAG exists in registry..."
+      docker manifest inspect $IMAGE:$TAG > /dev/null
+      if [[ $? -ne 0 ]]; then
+        echo "##vso[task.logissue type=error]Image/tag not found in registry."
+        exit 1
+      fi
+
+      az account set -s $(SUBSCRIPTION_ID)
+      args=("--name" "$APPNAME" "--resource-group" "${{ parameters.appResourceGroup }}" "--slot" "staging")
+
+      echo "##[command]App Service currently running image:"
+      CURRENT_IMAGE_NAME=$(az webapp config container show "${args[@]}" | jq -r '.[] | select(.name == "DOCKER_CUSTOM_IMAGE_NAME").value')
+      CURRENT_TAG=${CURRENT_IMAGE_NAME#*:}
+      echo "$CURRENT_IMAGE_NAME"
+
+      echo "##[command]Pull image and set environment tag..."
+      docker pull $IMAGE:$TAG
+      docker tag $IMAGE:$TAG $IMAGE:$GIT_COMMIT
+      docker push $IMAGE:$GIT_COMMIT
+
+      echo "##[command]Swapping App Service container to tag: $IMAGE:$GIT_COMMIT..."
+      az webapp config container set --docker-custom-image-name $IMAGE:$GIT_COMMIT "${args[@]}"
+
+      echo "##[command]Restarting App Service slot"
+      az webapp restart "${args[@]}"
+
+      APP_URL=$(az webapp show "${args[@]}" --query defaultHostName --output tsv)
+      FULL_URL="https://$APP_URL"
+      echo "##vso[task.setvariable variable=slotUrl;isOutput=true]$FULL_URL"
+    name: deploySlotOutputs
+    displayName: Deploy Container to Azure Web App Slot
+    env:
+      AZURE_SERVICE_PRINCIPAL_ID: $(AZURE_SERVICE_PRINCIPAL_ID)
+      AZURE_SERVICE_PRINCIPAL_SECRET: $(AZURE_SERVICE_PRINCIPAL_SECRET)

--- a/steps/azure_web_app_verify_git_hash.yml
+++ b/steps/azure_web_app_verify_git_hash.yml
@@ -1,0 +1,76 @@
+parameters:
+  - name: appName
+    type: string
+  - name: appUrl
+    type: string
+  - name: buildCommit
+    type: string
+  - name: retries
+    type: number
+    default: 6
+  - name: sleepTime
+    type: number
+    default: 30
+
+steps:
+  - script: |
+      verify_commit_hash() {
+        service_name=$1
+        service_url=$2
+        build_commit=$3
+        max_attempts=$4
+        sleep_time=$5
+
+        if [ -z "$max_attempts" ]; then
+          max_attempts=5
+        fi
+
+        attempt=0
+
+        while [ $attempt -lt $max_attempts ]; do
+          echo "Waiting for $service_name to start..."
+          sleep $(($sleep_time*attempt))
+          
+          echo "Calling $service_name /health endpoint (Attempt $(($attempt+1))/$max_attempts)"
+          echo "Service URL: $service_url"
+
+          # Get both the HTTP response and the status code
+          response=$(curl -s -w "\n%{http_code}" --connect-timeout 10 $service_url || echo "error")
+          http_status=$(echo "$response" | tail -n 1)
+          body=$(echo "$response" | sed '$d')
+
+          # Log the full response and status code for debugging
+          echo "HTTP Status Code: $http_status"
+          echo "Response Body: $body"
+
+          if [[ "$http_status" == "200" ]]; then
+            commit=$(echo "$body" | grep -o '"commit":"[^"]*"' | sed 's/"commit":"\([^"]*\)"/\1/')
+            if [[ "$commit" == "$build_commit" ]]; then
+              echo "$service_name commit hash matches: $commit"
+              return 0
+            else
+              echo "$service_name commit hash mismatch. Health: $commit, Build: $build_commit"
+            fi
+          else
+            echo "$service_name /health check failed with status code: $http_status. Retrying in $sleep_time seconds..."
+          fi
+          
+          attempt=$((attempt+1))
+        done
+
+        echo "$service_name /health check failed after $max_attempts attempts"
+        return 1
+      }
+
+      echo "${{ parameters.appName }}"
+      echo "${{ parameters.appUrl }}"
+      echo "${{ parameters.buildCommit }}"
+      echo ${{ parameters.retries }}
+      echo ${{ parameters.sleepTime }}
+
+      verify_commit_hash "${{ parameters.appName }}" "${{ parameters.appUrl }}" "${{ parameters.buildCommit }}" ${{ parameters.retries }} ${{ parameters.sleepTime }}
+    displayName: Verify deployed git hash
+    workingDirectory: $(Build.Repository.LocalPath)
+    env:
+      AZURE_SERVICE_PRINCIPAL_ID: $(AZURE_SERVICE_PRINCIPAL_ID)
+      AZURE_SERVICE_PRINCIPAL_SECRET: $(AZURE_SERVICE_PRINCIPAL_SECRET)


### PR DESCRIPTION
https://pins-ds.atlassian.net/browse/A2-1455

adds 2 new scripts
also fixes warning that `docker-custom-image-name` is deprecated, updates to `container-image-name`

steps/azure_web_app_deploy_slot.yml
- tags an image with the git hash
- sets the staging slots image name to this image 
- restarts staging slot
- returns staging slot url as an output

steps/azure_web_app_verify_git_hash.yml 
- checks for the commit hash on an endpoint
taken from other services with some minor changes, 0 initial wait, simple linear backoff