### PR TITLE
Feat/commit image tag

### DIFF
--- a/steps/azure_web_app_deploy_slot.yml
+++ b/steps/azure_web_app_deploy_slot.yml
@@ -1,3 +1,5 @@
+# Deploy to an Azure Web App by updating the docker container image tag to the git commit
+
 parameters:
   - name: appName
     type: string
@@ -7,47 +9,50 @@ parameters:
     type: string
   - name: repository
     type: string
+  - name: slot
+    type: string
+    default: "staging"
 
 steps:
   - script: |
-      APPNAME=${{ parameters.appName }}
-      IMAGE=${{ parameters.azurecrName }}.azurecr.io/${{ parameters.repository }}
-      FORMATTED_GIT_REF=$(echo $(Build.SourceBranch) | sed "s/refs\/heads\///;s/refs\/tags\///")
-      TAG="${FORMATTED_GIT_REF//\//.}"
-      GIT_COMMIT=$(resources.pipeline.build.sourceCommit)
+      set -e # exit if there are any errors
 
-      echo "IMAGE:$IMAGE"
-      echo "TAG:$TAG"
-      echo "GIT_COMMIT:$GIT_COMMIT"
+      APP_NAME=${{ parameters.appName }}
+      REPO=${{ parameters.azurecrName }}.azurecr.io/${{ parameters.repository }}
+      GIT_COMMIT=$(resources.pipeline.build.sourceCommit)
+      IMAGE_NAME="$REPO:$GIT_COMMIT"
+
+      echo "Deploying image: $IMAGE_NAME to $APP_NAME"
 
       echo "logging into az"
+      # use container registry subscription
       az account set -s $(CONTAINER_REGISTRY_SUBSCRIPTION_ID)
       az acr login --name $(azurecrName) || { echo "##vso[task.logissue type=error]Login to container registry failed."; exit 1; }
 
-      echo "##[command]Checking image $IMAGE:$TAG exists in registry..."
-      docker manifest inspect $IMAGE:$TAG > /dev/null
+      echo "##[command]Checking image $IMAGE_NAME exists in registry..."
+      docker manifest inspect $IMAGE_NAME > /dev/null
       if [[ $? -ne 0 ]]; then
-        echo "##vso[task.logissue type=error]Image/tag not found in registry."
+        echo "##vso[task.logissue type=error]Image not found in registry."
         exit 1
       fi
+      echo "##[command]Image exists"
 
+      # switch to app service subscription
       az account set -s $(SUBSCRIPTION_ID)
-      args=("--name" "$APPNAME" "--resource-group" "${{ parameters.appResourceGroup }}" "--slot" "staging")
-
-      echo "##[command]App Service currently running image:"
+      args=("--name" "$APP_NAME" "--resource-group" "${{ parameters.appResourceGroup }}")
+      if [[ ${{ parameters.slot}} != "default" ]]; then
+        args+=( "--slot" "${{parameters.slot}}")
+      fi
+      
+      echo "##[command]Checking current image (args: ${args[@]})"
       CURRENT_IMAGE_NAME=$(az webapp config container show "${args[@]}" | jq -r '.[] | select(.name == "DOCKER_CUSTOM_IMAGE_NAME").value')
       CURRENT_TAG=${CURRENT_IMAGE_NAME#*:}
-      echo "$CURRENT_IMAGE_NAME"
+      echo "##[command]App Service currently running image:$CURRENT_IMAGE_NAME"
 
-      echo "##[command]Pull image and set environment tag..."
-      docker pull $IMAGE:$TAG
-      docker tag $IMAGE:$TAG $IMAGE:$GIT_COMMIT
-      docker push $IMAGE:$GIT_COMMIT
+      echo "##[command]Swapping App Service container: $IMAGE_NAME"
+      az webapp config container set --container-image-name $IMAGE_NAME "${args[@]}"
 
-      echo "##[command]Swapping App Service container to tag: $IMAGE:$GIT_COMMIT..."
-      az webapp config container set --container-image-name $IMAGE:$GIT_COMMIT "${args[@]}"
-
-      echo "##[command]Restarting App Service slot"
+      echo "##[command]Restarting App Service slot (${{parameters.slot}})"
       az webapp restart "${args[@]}"
 
       APP_URL=$(az webapp show "${args[@]}" --query defaultHostName --output tsv)

--- a/steps/azure_web_app_docker_build_push.yml
+++ b/steps/azure_web_app_docker_build_push.yml
@@ -30,6 +30,7 @@ steps:
       git fetch --tags
 
       git_tags=$(git tag -l --points-at HEAD)
+      git_commit=$(Build.SourceVersion)
 
       build_args="${{ join(' ', parameters.buildArgs) }}"
 
@@ -42,6 +43,11 @@ steps:
       for git_tag in $git_tags; do
         additional_tags+=(-t "$IMAGE:$git_tag")
       done
+      
+      # tag images with the git commit hash
+      additional_tags+=(-t "$IMAGE:$git_commit")
+      
+      echo "Image tags for build: $TAG, ci-build, ${git_tags[@]}, $git_commit"
       
       docker build . \
       -f ${{ parameters.dockerfilePath }} \
@@ -57,8 +63,11 @@ steps:
         docker push $IMAGE:$TAG || { echo "##vso[task.logissue type=error]Push failed..."; exit 1; }
         
         for git_tag in $git_tags; do
-          docker push $IMAGE:$git_tag || { echo "##vso[task.logissue type=error]Push failed..."; exit 1; }
+          docker push $IMAGE:$git_tag || { echo "##vso[task.logissue type=error]Push failed for git tag..."; exit 1; }
         done
+        
+        # push image with git commit tag
+        docker push $IMAGE:$git_commit || { echo "##vso[task.logissue type=error]Push failed for git commit tag..."; exit 1; }
 
         docker save $IMAGE:ci-build -o $(Build.ArtifactStagingDirectory)/image.tar
       else


### PR DESCRIPTION
Use git commit has for tagging docker builds, and for deployment.

Backwards compatible as the `steps/azure_web_app_deploy_slot.yml` step is not yet in use by consuming projects.

https://pins-ds.atlassian.net/browse/DEV-337