### PR TITLE
fix: adding token authentication for git verify

### DIFF
--- a/steps/azure_web_app_verify_git_hash.yml
+++ b/steps/azure_web_app_verify_git_hash.yml
@@ -11,6 +11,15 @@ parameters:
   - name: sleepTime
     type: number
     default: 30
+  - name: appRegistrationClientId
+    type: string
+    default: ""
+  - name: auth_enabled
+    type: string 
+    default: "false"
+  - name: env
+    type: string
+    default: "dev"
 
 steps:
   - script: |
@@ -34,8 +43,20 @@ steps:
           echo "Calling $service_name /health endpoint (Attempt $(($attempt+1))/$max_attempts)"
           echo "Service URL: $service_url"
 
-          # Get both the HTTP response and the status code
-          response=$(curl -s -w "\n%{http_code}" --connect-timeout 10 $service_url || echo "error")
+          if [[ "${{ parameters.env}}" != "prod"  && "${{ parameters.auth_enabled}}" == "true" ]]; then
+            echo "..........Non-Prod environment and Auth is enabled..........."
+            echo "##[command]Generating TOKEN"
+            TOKEN=$(az account get-access-token --query accessToken -o tsv --resource "${{ parameters.appRegistrationClientId}}")
+            # Get HTTP response 
+            response=$(curl -s -w "\n%{http_code}" --connect-timeout 10 $service_url -H "Authorization: Bearer $TOKEN"|| echo "error")
+            
+          else
+            echo "....................Auth Disabled..............."
+            # Get HTTP response
+            response=$(curl -s -w "\n%{http_code}" --connect-timeout 10 $service_url || echo "error")
+          fi
+
+          # Get status code
           http_status=$(echo "$response" | tail -n 1)
           body=$(echo "$response" | sed '$d')
 
@@ -67,6 +88,9 @@ steps:
       echo "${{ parameters.buildCommit }}"
       echo ${{ parameters.retries }}
       echo ${{ parameters.sleepTime }}
+      echo "${{ parameters.appRegistrationClientId}}"
+      echo "${{ parameters.auth_enabled}}"
+      echo "${{ parameters.env}}"
 
       verify_commit_hash "${{ parameters.appName }}" "${{ parameters.appUrl }}" "${{ parameters.buildCommit }}" ${{ parameters.retries }} ${{ parameters.sleepTime }}
     displayName: Verify deployed git hash


### PR DESCRIPTION
Adding script to generate token and make use of it to receive an HTTP response for application with Easy authentication 
 enabled 

Part of https://pins-ds.atlassian.net/browse/DEV-323 