### PR TITLE
fix: remove docker build publish steps

### DIFF
--- a/steps/azure_web_app_docker_build_push.yml
+++ b/steps/azure_web_app_docker_build_push.yml
@@ -49,6 +49,7 @@ steps:
       
       echo "Image tags for build: $TAG, ci-build, ${git_tags[@]}, $git_commit"
       
+      echo "##[command]docker build"
       docker build . \
       -f ${{ parameters.dockerfilePath }} \
       -t $IMAGE:$TAG \
@@ -57,9 +58,11 @@ steps:
       "${args[@]}"
 
       if [[ "$IS_PR" != "true" ]]; then
+        echo "##[command]docker login"
         az account set -s $(CONTAINER_REGISTRY_SUBSCRIPTION_ID)
         az acr login --name ${{ parameters.azurecrName }} || { echo "##vso[task.logissue type=error]Login to container registry failed."; exit 1; }
 
+        echo "##[command]docker push"
         docker push $IMAGE:$TAG || { echo "##vso[task.logissue type=error]Push failed..."; exit 1; }
         
         for git_tag in $git_tags; do
@@ -68,21 +71,9 @@ steps:
         
         # push image with git commit tag
         docker push $IMAGE:$git_commit || { echo "##vso[task.logissue type=error]Push failed for git commit tag..."; exit 1; }
-
-        docker save $IMAGE:ci-build -o $(Build.ArtifactStagingDirectory)/image.tar
+      echo "##[command]docker push complete"
       else
         echo "##[warning]Build is for a Pull Request, won't push image to Container Registry..."
       fi
     displayName: Build and Push Docker Image to ACR
     workingDirectory: ${{ parameters.workingDirectory }}
-  - script: |
-      REPOSITORY=${{ parameters.repository }}
-      ARTIFACT_NAME=$(cut -d "/" -f2 <<< "$REPOSITORY")
-
-      echo "##vso[task.setvariable variable=artifactName]$ARTIFACT_NAME"
-    condition: ne(variables['isPR'], 'true')
-    displayName: Set artifact name
-  - publish: $(Build.ArtifactStagingDirectory)
-    artifact: $(artifactName)
-    condition: ne(variables['isPR'], 'true')
-    displayName: Publish Docker Image as Artifact


### PR DESCRIPTION
[fix: remove docker build publish steps](https://github.com/Planning-Inspectorate/common-pipeline-templates/commit/cb47f4f3affc5990928d635dc14a1b88d2ff5067)

the DevOps artifact is not required or used, so this simplifies the pipeline step

https://pins-ds.atlassian.net/browse/DEV-474