### PR TITLE
fix: use azurecrName parameter instead of variable

### DIFF
--- a/steps/azure_web_app_deploy_slot.yml
+++ b/steps/azure_web_app_deploy_slot.yml
@@ -30,7 +30,7 @@ steps:
       echo "logging into az"
       # use container registry subscription
       az account set -s $(CONTAINER_REGISTRY_SUBSCRIPTION_ID)
-      az acr login --name $(azurecrName) || { echo "##vso[task.logissue type=error]Login to container registry failed."; exit 1; }
+      az acr login --name ${{ parameters.azurecrName }} || { echo "##vso[task.logissue type=error]Login to container registry failed."; exit 1; }
 
       echo "##[command]Checking image $IMAGE_NAME exists in registry..."
       docker manifest inspect $IMAGE_NAME > /dev/null


### PR DESCRIPTION
Previously this just happened to work as most pipeline users had a variable with the correct name and the same value as the parameter.